### PR TITLE
doc: update gatsby logo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://gatsbyjs.org">
-    <img alt="Gatsby" src="https://www.gatsbyjs.org/monogram.svg" height="60" />
+    <img alt="Gatsby" src="https://www.gatsbyjs.com/Gatsby-Monogram.svg" height="60" />
     <img alt="Gatsby" src="https://static.agilitycms.com/layout/img/logo-original.svg" width="200" />
   </a>
 </p>


### PR DESCRIPTION
The Gatsby logo url changed and it's not showing up on the README.md, here's the new one :)